### PR TITLE
【サーバーサイド】保存内容の変更

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @index = Text.all
+    @index = Text.all.reverse
   end
 
   def new
@@ -19,7 +19,7 @@ class TextsController < ApplicationController
 
   private
   def text_params
-    params.require(:text).permit(:text)
+    params.require(:text).permit(:text,:date,:title)
   end
 end
 

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -9,7 +9,7 @@
 <body>
   <header>
     <h1>ToDo By Rails</h1>
-    <h3>ログイン</h3>
+    <h3>sign in</h3>
   </header>
   <main>
     <div class="ListTitle">
@@ -22,8 +22,8 @@
     <div class="createdList">
       <% @index.each do |text| %>
         <div class="show_lists">
-          <div class="show_date">2020-07-02</div>
-          <div class="show_title">今日やること</div>
+          <div class="show_date"><%= text.date %></div>
+          <div class="show_title"><%= text.title %></div>
           <form action="#" name="input">
             <div class="show_text"><input type="checkbox" name="check"><%= text.text %></div>
             <div class="more_list">


### PR DESCRIPTION
##What
新規投稿画面から保存できる内容を増やした。
テキストのみの保存ができるようにしていたが新しく日付とタイトルの保存ができるようにした。

##Why
利便性を上げるため